### PR TITLE
87  add user overview

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SessionController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SessionController.java
@@ -34,7 +34,9 @@ public class SessionController {
 
         Session createdSession = sessionService.createSession(newSession, sessionPostDTO.getToken());
 
-        return DTOMapper.INSTANCE.convertEntitytoSessionGetDTO(createdSession);
+        SessionGetDTO dto = DTOMapper.INSTANCE.convertEntitytoSessionGetDTO(createdSession);
+        dto.setUsernames(sessionService.getJoinedUsernames(createdSession));
+        return dto;
     }
 
     @PutMapping("/session/{sessionCode}")
@@ -43,7 +45,9 @@ public class SessionController {
 
         Session session = sessionService.joinSession(sessionCode, sessionPutDTO);
 
-        return DTOMapper.INSTANCE.convertEntitytoSessionGetDTO(session);
+        SessionGetDTO dto = DTOMapper.INSTANCE.convertEntitytoSessionGetDTO(session);
+        dto.setUsernames(sessionService.getJoinedUsernames(session));
+        return dto;
     }
 
     @GetMapping("/session/{sessionCode}/next")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SessionController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SessionController.java
@@ -98,7 +98,7 @@ public class SessionController {
 
     @DeleteMapping("/session/{sessionCode}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void leaveSession(@PathVariable String sessionCode, @RequestParam String token) {
-        sessionService.leaveSession(sessionCode, token);
+    public void leaveSession(@PathVariable String sessionCode, @RequestBody SessionPutDTO sessionPutDTO) {
+        sessionService.leaveSession(sessionCode, sessionPutDTO.getToken());
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SessionController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SessionController.java
@@ -95,4 +95,10 @@ public class SessionController {
     public Integer getSessionTime(@PathVariable String sessionCode) {
         return sessionService.getSessionTiming(sessionCode);
     }
+
+    @DeleteMapping("/session/{sessionCode}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void leaveSession(@PathVariable String sessionCode, @RequestParam String token) {
+        sessionService.leaveSession(sessionCode, token);
+    }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/GuestUserRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/GuestUserRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
+import java.util.List;
+import ch.uzh.ifi.hase.soprafs26.entity.Session;
 
 @Repository("guestUserRepository")
 public interface GuestUserRepository extends JpaRepository<GuestUser, Long> {
@@ -15,6 +17,6 @@ public interface GuestUserRepository extends JpaRepository<GuestUser, Long> {
 
     long deleteByExpiresAtBefore(Instant now);
     
-    java.util.List<GuestUser> findAllByCurrentSession(ch.uzh.ifi.hase.soprafs26.entity.Session currentSession);
+    List<GuestUser> findAllByCurrentSession(Session currentSession);
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/GuestUserRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/GuestUserRepository.java
@@ -14,5 +14,7 @@ public interface GuestUserRepository extends JpaRepository<GuestUser, Long> {
     GuestUser findByUsername(String name);
 
     long deleteByExpiresAtBefore(Instant now);
+    
+    java.util.List<GuestUser> findAllByCurrentSession(ch.uzh.ifi.hase.soprafs26.entity.Session currentSession);
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/UserRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/UserRepository.java
@@ -4,6 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.entity.Session;
+import java.util.List;
 
 @Repository("userRepository")
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -15,5 +17,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
 	User findByToken(String token);
 
-	java.util.List<User> findAllByCurrentSession(ch.uzh.ifi.hase.soprafs26.entity.Session currentSession);
+	List<User> findAllByCurrentSession(Session currentSession);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/UserRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/UserRepository.java
@@ -14,4 +14,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	User findByEmail(String email);
 
 	User findByToken(String token);
+
+	java.util.List<User> findAllByCurrentSession(ch.uzh.ifi.hase.soprafs26.entity.Session currentSession);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SessionGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SessionGetDTO.java
@@ -6,6 +6,7 @@ public class SessionGetDTO {
     private long sessionId;
     private long hostId;
     private Integer joinedUsers;
+    private java.util.List<String> usernames;
 
     public String getSessionCode() {
         return sessionCode;
@@ -45,5 +46,13 @@ public class SessionGetDTO {
 
     public void setJoinedUsers(Integer joinedUsers) {
         this.joinedUsers = joinedUsers;
+    }
+
+    public java.util.List<String> getUsernames() {
+        return usernames;
+    }
+
+    public void setUsernames(java.util.List<String> usernames) {
+        this.usernames = usernames;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SessionGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SessionGetDTO.java
@@ -1,4 +1,5 @@
 package ch.uzh.ifi.hase.soprafs26.rest.dto;
+import java.util.List;
 
 public class SessionGetDTO {
     private String sessionCode;
@@ -6,7 +7,7 @@ public class SessionGetDTO {
     private long sessionId;
     private long hostId;
     private Integer joinedUsers;
-    private java.util.List<String> usernames;
+    private List<String> usernames;
 
     public String getSessionCode() {
         return sessionCode;
@@ -48,11 +49,11 @@ public class SessionGetDTO {
         this.joinedUsers = joinedUsers;
     }
 
-    public java.util.List<String> getUsernames() {
+    public List<String> getUsernames() {
         return usernames;
     }
 
-    public void setUsernames(java.util.List<String> usernames) {
+    public void setUsernames(List<String> usernames) {
         this.usernames = usernames;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -182,6 +182,66 @@ public class SessionService {
         return session;
     }
 
+    public void leaveSession(String sessionCode, String userToken) {
+        Session session = sessionRepository.findSessionBySessionCode(sessionCode);
+
+        if (session == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Session could not be found.");
+        }
+
+        Long expectedId;
+        boolean isGuest = userToken.startsWith("Guest");
+
+        if (isGuest) {
+            GuestUser guestUser = guestUserRepository.findByToken(userToken);
+            if (guestUser == null) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Guest user not found");
+            }
+            expectedId = guestUser.getId();
+            
+            // Remove from session
+            if (guestUser.getCurrentSession() != null && guestUser.getCurrentSession().getSessionId().equals(session.getSessionId())) {
+                guestUser.setCurrentSession(null);
+                guestUserRepository.save(guestUser);
+                guestUserRepository.flush();
+            }
+        } else {
+            User user = userRepository.findByToken(userToken);
+            if (user == null) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found");
+            }
+            expectedId = user.getId();
+            
+            // Remove from session
+            if (user.getCurrentSession() != null && user.getCurrentSession().getSessionId().equals(session.getSessionId())) {
+                user.setCurrentSession(null);
+                userRepository.save(user);
+                userRepository.flush();
+            }
+        }
+
+        if (session.getHostId().equals(expectedId)) {
+            session.setStatus(SessionStatus.OFFLINE);
+            sessionRepository.save(session);
+            sessionRepository.flush();
+            broadcastSessionEnded(sessionCode);
+        } else {
+            int currentJoined = session.getJoinedUsers();
+            if (currentJoined > 1) {
+                session.setJoinedUsers(currentJoined - 1);
+                sessionRepository.save(session);
+                sessionRepository.flush();
+            }
+
+            Map<String, Object> lobbyUpdate = new HashMap<>();
+            lobbyUpdate.put("joinedUsers", session.getJoinedUsers());
+            lobbyUpdate.put("maxPlayers", session.getMaxPlayers());
+            lobbyUpdate.put("usernames", getJoinedUsernames(session));
+
+            messagingTemplate.convertAndSend((String)("/topic/session/" + sessionCode + "/lobby"), (Object) lobbyUpdate);
+        }
+    }
+
     private void checkValidSessionCreation(Session newSession, String userToken) {
         String sessionName = newSession.getSessionName();
         Integer maxPlayers = newSession.getMaxPlayers();

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -174,6 +174,7 @@ public class SessionService {
         Map<String, Object> lobbyUpdate = new HashMap<>();
         lobbyUpdate.put("joinedUsers", session.getJoinedUsers());
         lobbyUpdate.put("maxPlayers", session.getMaxPlayers());
+        lobbyUpdate.put("usernames", getJoinedUsernames(session));
 
         // updated number of users who have already joined the session
         messagingTemplate.convertAndSend((String) ("/topic/session/" + sessionCode + "/lobby"), (Object) lobbyUpdate);
@@ -396,5 +397,18 @@ public class SessionService {
         Session session = getSessionByCode(sessionCode);
 
         return session.getTimePerRound();
+    }
+
+    public List<String> getJoinedUsernames(Session session) {
+        List<String> usernames = new ArrayList<>();
+        List<User> users = userRepository.findAllByCurrentSession(session);
+        for (User user : users) {
+            usernames.add(user.getUsername());
+        }
+        List<GuestUser> guestUsers = guestUserRepository.findAllByCurrentSession(session);
+        for (GuestUser guest : guestUsers) {
+            usernames.add(guest.getUsername());
+        }
+        return usernames;
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SessionControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SessionControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
@@ -374,5 +375,18 @@ class SessionControllerTest {
 
                 mockMvc.perform(getRequest)
                 .andExpect(status().isConflict());
+        }
+
+        @Test
+        void leaveSession_validInput_returnsNoContent() throws Exception {
+                SessionPutDTO sessionPutDTO = new SessionPutDTO();
+                sessionPutDTO.setToken("userToken");
+
+                Mockito.doNothing().when(sessionService).leaveSession(eq("test1234"), eq("userToken"));
+
+                mockMvc.perform(delete("/session/test1234")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(sessionPutDTO)))
+                        .andExpect(status().isNoContent());
         }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
@@ -491,4 +491,81 @@ class SessionServiceTest {
                 assertEquals(404, exception.getStatusCode().value());
                 assertEquals("Session could not be found.", exception.getReason());
         }
+
+        @Test
+        void leaveSession_unknownSession_throwsNotFound() {
+                Mockito.when(sessionRepository.findSessionBySessionCode("MISSING")).thenReturn(null);
+
+                ResponseStatusException exception = assertThrows(
+                                ResponseStatusException.class,
+                                () -> sessionService.leaveSession("MISSING", "someToken"));
+
+                assertEquals(404, exception.getStatusCode().value());
+                assertEquals("Session could not be found.", exception.getReason());
+        }
+
+        @Test
+        void leaveSession_unknownGuestUser_throwsNotFound() {
+                Session session = new Session();
+                Mockito.when(sessionRepository.findSessionBySessionCode("ABCDE")).thenReturn(session);
+                Mockito.when(guestUserRepository.findByToken("GuestToken")).thenReturn(null);
+
+                ResponseStatusException exception = assertThrows(
+                                ResponseStatusException.class,
+                                () -> sessionService.leaveSession("ABCDE", "GuestToken"));
+
+                assertEquals(404, exception.getStatusCode().value());
+                assertEquals("Guest user not found", exception.getReason());
+        }
+
+        @Test
+        void leaveSession_hostLeaves_setsOfflineAndBroadcastsEnd() {
+                Session session = new Session();
+                session.setSessionId(1L);
+                session.setSessionCode("ABCDE");
+                session.setHostId(10L);
+                session.setStatus(SessionStatus.ONLINE);
+
+                User user = new User();
+                user.setId(10L);
+                user.setCurrentSession(session);
+
+                Mockito.when(sessionRepository.findSessionBySessionCode("ABCDE")).thenReturn(session);
+                Mockito.when(userRepository.findByToken("HostToken")).thenReturn(user);
+
+                sessionService.leaveSession("ABCDE", "HostToken");
+
+                assertEquals(SessionStatus.OFFLINE, session.getStatus());
+                assertNull(user.getCurrentSession());
+                Mockito.verify(sessionRepository).save(session);
+                Mockito.verify(userRepository).save(user);
+                Mockito.verify(messagingTemplate).convertAndSend("/topic/session/ABCDE/end", "ABCDE");
+        }
+
+        @Test
+        void leaveSession_guestParticipantLeaves_decrementsCountAndBroadcastsLobbyUpdate() {
+                Session session = new Session();
+                session.setSessionId(1L);
+                session.setSessionCode("ABCDE");
+                session.setHostId(10L);
+                session.setJoinedUsers(3);
+                session.setMaxPlayers(10);
+
+                GuestUser guest = new GuestUser();
+                guest.setId(22L);
+                guest.setCurrentSession(session);
+
+                Mockito.when(sessionRepository.findSessionBySessionCode("ABCDE")).thenReturn(session);
+                Mockito.when(guestUserRepository.findByToken("GuestToken")).thenReturn(guest);
+                Mockito.when(userRepository.findAllByCurrentSession(session)).thenReturn(List.of());
+                Mockito.when(guestUserRepository.findAllByCurrentSession(session)).thenReturn(List.of());
+
+                sessionService.leaveSession("ABCDE", "GuestToken");
+
+                assertEquals(2, session.getJoinedUsers());
+                assertNull(guest.getCurrentSession());
+                Mockito.verify(sessionRepository).save(session);
+                Mockito.verify(guestUserRepository).save(guest);
+                Mockito.verify(messagingTemplate).convertAndSend(Mockito.eq("/topic/session/ABCDE/lobby"), Mockito.<Object>any());
+        }
 }


### PR DESCRIPTION
#110 
Added backend logic for "Joined Users" box on the lobby screen displaying the usernames of all joined users. 

- Added getJoinedUsernames method in SessionService that queries both UserRepository and GuestUserRepository for users linked to the session and returns their usernames.
 
- Added usernames field to SessionGetDTO and populated it in createSession and joinSession controller responses.
 
- Included usernames in the WebSocket lobby update payload so all participants receive the updated list in real-time when someone joins.

 
#38 
Added functionality that when host leaves, the session is terminated for all joined users.

- Added leaveSession method in SessionService that identifies the user by token, checks if they are the host, and either terminates the session (broadcasting to /end topic) or decrements the joined user count and broadcasts an updated lobby state.
 
- Added DELETE /session/{sessionCode}?token= endpoint in SessionController to trigger the leave logic.


 
Added functionality that when a non-host user leaves, the joined user count and username list are updated in real-time for all remaining participants.

- leaveSession unlinks the user from the session, decrements joinedUsers, and broadcasts an updated lobby payload (count + usernames) via WebSocket.