### PR TITLE
#72 changed endpoint for the two get requests and added functionality to get all histories saved by a single user.

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/HistoryController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/HistoryController.java
@@ -8,6 +8,9 @@ import ch.uzh.ifi.hase.soprafs26.service.HistoryService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @RestController
 public class HistoryController {
 
@@ -24,11 +27,25 @@ public class HistoryController {
     }
 
 
-    @GetMapping("/histories/{historyId}")
+    @GetMapping("/users/{userId}/histories/{historyId}")
     @ResponseStatus(HttpStatus.OK)
-    public HistoryGetDTO getHistory(@PathVariable Long historyId) {
-        History history = historyService.getHistoryByHistoryId(historyId);
+    public HistoryGetDTO getHistory(@PathVariable Long userId, @PathVariable Long historyId) {
+        History history = historyService.getHistoryByHistoryId(userId, historyId);
 
         return DTOMapper.INSTANCE.convertEntityToHistoryGetDTO(history);
+    }
+
+    @GetMapping("/users/{userId}/histories")
+    @ResponseStatus(HttpStatus.OK)
+    public List<HistoryGetDTO> getAllHistoryOfUser(@PathVariable Long userId) {
+
+        List<History> histories = historyService.getHistoriesOfUser(userId);
+        List<HistoryGetDTO> historyGetDTOs = new ArrayList<>();
+
+        for (History history : histories) {
+            historyGetDTOs.add(DTOMapper.INSTANCE.convertEntityToHistoryGetDTO(history));
+        }
+
+        return historyGetDTOs;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/HistoryRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/HistoryRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Repository("historyRepository")
 public interface HistoryRepository extends JpaRepository<History, Long> {
 
-    History findByHistoryId(Long historyId);
+    History findByUserIdAndHistoryId(Long userId, Long historyId);
 
     List<History> findAllByUserId(Long userId);
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/HistoryService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/HistoryService.java
@@ -90,11 +90,19 @@ public class HistoryService {
         return user;
     }
 
-    public History getHistoryByHistoryId(Long historyId) {
-        History history =  historyRepository.findByHistoryId(historyId);
+    public History getHistoryByHistoryId(Long userId, Long historyId) {
+        History history =  historyRepository.findByUserIdAndHistoryId(userId, historyId);
         if (history == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "History with historyId " + historyId + " not found.");
         }
         return history;
+    }
+
+    public List<History> getHistoriesOfUser(Long userId) {
+
+        if (userId == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "UserId is required.");
+        }
+        return this.historyRepository.findAllByUserId(userId);
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/HistoryControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/HistoryControllerTest.java
@@ -112,9 +112,9 @@ class HistoryControllerTest {
         history.setUserId(7L);
         history.setMovies(List.of());
 
-        when(historyService.getHistoryByHistoryId(1L)).thenReturn(history);
+        when(historyService.getHistoryByHistoryId(7L, 1L)).thenReturn(history);
 
-        MockHttpServletRequestBuilder getRequest = get("/histories/1")
+        MockHttpServletRequestBuilder getRequest = get("/users/7/histories/1")
                 .contentType(MediaType.APPLICATION_JSON);
 
         mockMvc.perform(getRequest)
@@ -129,10 +129,10 @@ class HistoryControllerTest {
 
     @Test
     void getHistory_unknownSession_returnsNotFound() throws Exception {
-        when(historyService.getHistoryByHistoryId(1L))
+        when(historyService.getHistoryByHistoryId(7L, 1L))
                 .thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Session could not be found."));
 
-        MockHttpServletRequestBuilder getRequest = get("/histories/1");
+        MockHttpServletRequestBuilder getRequest = get("/users/7/histories/1");
 
         mockMvc.perform(getRequest)
                 .andExpect(status().isNotFound());
@@ -141,7 +141,7 @@ class HistoryControllerTest {
     @Test
     void getHistory_invalidId_returnsBadRequest() throws Exception {
 
-        MockHttpServletRequestBuilder getRequest = get("/histories/abc");
+        MockHttpServletRequestBuilder getRequest = get("/users/7/histories/abc");
 
         mockMvc.perform(getRequest)
                 .andExpect(status().isBadRequest());
@@ -162,14 +162,56 @@ class HistoryControllerTest {
         history.setUserId(7L);
         history.setMovies(List.of(entry));
 
-        when(historyService.getHistoryByHistoryId(1L)).thenReturn(history);
+        when(historyService.getHistoryByHistoryId(7L, 1L)).thenReturn(history);
 
-        MockHttpServletRequestBuilder getRequest = get("/histories/1");
+        MockHttpServletRequestBuilder getRequest = get("/users/7/histories/1");
 
         mockMvc.perform(getRequest)
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.movies[0].movieId", is(10)))
                 .andExpect(jsonPath("$.movies[0].score", is(5)));
+    }
+
+    @Test
+    void getAllHistoryOfUser_withHistory_returnsJson() throws Exception {
+        HistoryMovieEntry entry = new HistoryMovieEntry();
+        entry.setMovieId(10L);
+        entry.setScore(5);
+
+        History history = new History();
+        history.setSessionCode("ABCDE");
+        history.setHistoryId(1L);
+        history.setCreationDate(new Date());
+        history.setSessionName("Test Round");
+        history.setJoinedUsers(3);
+        history.setUserId(7L);
+        history.setMovies(List.of(entry));
+
+        when(historyService.getHistoriesOfUser(7L)).thenReturn(List.of(history));
+
+        MockHttpServletRequestBuilder getRequest = get("/users/7/histories");
+
+        mockMvc.perform(getRequest)
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void getAllHistoryOfUser_noHistory_returnsEmptyArray() throws Exception {
+        when(historyService.getHistoriesOfUser(7L)).thenReturn(List.of());
+
+        MockHttpServletRequestBuilder getRequest = get("/users/7/histories");
+
+        mockMvc.perform(getRequest)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isEmpty());
+    }
+
+    @Test
+    void getAllHistoryOfUser_invalidUserId_returnsBadRequest() throws Exception {
+        MockHttpServletRequestBuilder getRequest = get("/users/abc/histories");
+
+        mockMvc.perform(getRequest)
+                .andExpect(status().isBadRequest());
     }
 
     private String asJsonString(Object object) {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/HistoryServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/HistoryServiceTest.java
@@ -17,11 +17,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -191,26 +192,73 @@ class HistoryServiceTest {
         history.setSessionCode("ABCDE");
         history.setHistoryId(1L);
 
-        when(historyRepository.findByHistoryId(1L)).thenReturn(history);
+        when(historyRepository.findByUserIdAndHistoryId(7L, 1L)).thenReturn(history);
 
-        History result = historyService.getHistoryByHistoryId(1L);
+        History result = historyService.getHistoryByHistoryId(7L, 1L);
 
         assertEquals(1L, result.getHistoryId());
         assertEquals("ABCDE", result.getSessionCode());
 
-        verify(historyRepository, times(1)).findByHistoryId(1L);
+        verify(historyRepository, times(1)).findByUserIdAndHistoryId(7L, 1L);
     }
 
     @Test
     void getHistoryByHistoryId_invalidId_throwsNotFound() {
-        when(historyRepository.findByHistoryId(1L)).thenReturn(null);
+        when(historyRepository.findByUserIdAndHistoryId(7L, 1L)).thenReturn(null);
 
         ResponseStatusException ex = assertThrows(ResponseStatusException.class,
-                () -> historyService.getHistoryByHistoryId(1L));
+                () -> historyService.getHistoryByHistoryId(7L, 1L));
 
         assertEquals(404, ex.getStatusCode().value());
         assertEquals("History with historyId 1 not found.", ex.getReason());
 
-        verify(historyRepository, times(1)).findByHistoryId(1L);
+        verify(historyRepository, times(1)).findByUserIdAndHistoryId(7L, 1L);
+    }
+
+    @Test
+    void getHistoriesOfUser_validId_returnsHistories() {
+        History history = new History();
+        history.setSessionCode("ABCDE");
+        history.setHistoryId(1L);
+        history.setUserId(7L);
+
+        History history2 = new History();
+        history2.setSessionCode("EDCBA");
+        history2.setHistoryId(2L);
+        history2.setUserId(7L);
+
+        when(historyRepository.findAllByUserId(7L)).thenReturn(Arrays.asList(history, history2));
+
+        List<History> result = historyService.getHistoriesOfUser(7L);
+
+        assertEquals(2, result.size());
+        assertEquals("ABCDE", result.get(0).getSessionCode());
+        assertEquals("EDCBA", result.get(1).getSessionCode());
+        assertEquals(1L, result.get(0).getHistoryId());
+        assertNotNull(result);
+        verify(historyRepository, times(1)).findAllByUserId(7L);
+    }
+
+    @Test
+    void getHistoriesOfUser_nullId_throwsBadRequest() {
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> historyService.getHistoriesOfUser(null));
+
+        assertEquals(400, ex.getStatusCode().value());
+        assertEquals("UserId is required.", ex.getReason());
+    }
+
+    @Test
+    void getHistoriesOfUser_validId_returnsEmptyList() {
+
+        when(historyRepository.findAllByUserId(1L)).thenReturn(Collections.emptyList());
+
+        List<History> result = historyService.getHistoriesOfUser(1L);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+
+        verify(historyRepository, times(1)).findAllByUserId(1L);
     }
 }


### PR DESCRIPTION
#72 The logic behind the endpoints would have ended with two ids behind each other or a param, since we don't want that and histories are individual, I changed the endpoints, fixed the tests and also added the whole functionality to get a List of all histories linked to a specific user.