### PR TITLE
208 devtask enable countdown skip for the host when all users have logged in their vote

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SessionController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SessionController.java
@@ -58,6 +58,16 @@ public class SessionController {
         return DTOMapper.INSTANCE.convertMovieGetDTOtoEntity(movie);
     }
 
+    @PostMapping("/session/{sessionCode}/next/request")
+    @ResponseStatus(HttpStatus.OK)
+    public MovieGetDTO requestNextMovie(@PathVariable String sessionCode,
+            @RequestHeader("Authorization") String token) {
+
+        Movie movie = sessionService.forceNextMovie(sessionCode, token);
+
+        return DTOMapper.INSTANCE.convertMovieGetDTOtoEntity(movie);
+    }
+
     @GetMapping("/session/{sessionCode}/current")
     @ResponseStatus(HttpStatus.OK)
     public MovieGetDTO getCurrentMovie(@PathVariable String sessionCode) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -297,10 +297,10 @@ public class SessionService {
 
     public Movie forceNextMovie(String sessionCode, String token) {
         Session session = sessionRepository.findSessionBySessionCode(sessionCode);
-        if (session == null)
+        if (session == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Session not found");
+        }
 
-        // 1. Correct Host Validation
         Long currentUserId = null;
         User user = userRepository.findByToken(token);
         GuestUser guestUser = guestUserRepository.findByToken(token);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -319,7 +319,6 @@ public class SessionService {
         Integer joinedUsers = session.getJoinedUsers();
 
         if (joinedUsers != null && actualVotes < joinedUsers) {
-            System.out.println("DB Votes: " + actualVotes + " Joined: " + joinedUsers);
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Not all users have voted yet");
         }
 
@@ -502,7 +501,6 @@ public class SessionService {
             broadcastSessionEnded(sessionCode);
         }
 
-        System.out.println("Votes received for movie " + votePutDTO.getMovieId() + ": " + votesReceived);
     }
 
     public List<MovieResultDTO> calculateFullLeaderboard(String sessionCode) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -487,6 +487,21 @@ public class SessionService {
                 votesReceived,
                 session.getJoinedUsers());
 
+        Integer joinedUsers = session.getJoinedUsers();
+        Integer currentMovieIndex = session.getCurrentMovieIndex();
+        String sessionCode = session.getSessionCode();
+        List<Long> movieIds = session.getSessionMovieIds();
+
+        // this meeans that we are at the end of the game and all users have voted
+        if ((currentMovieIndex == null || currentMovieIndex < 0 || currentMovieIndex >= movieIds.size())
+                && joinedUsers != null && votesReceived >= joinedUsers) {
+            session.setStatus(SessionStatus.OFFLINE);
+            sessionRepository.save(session);
+            sessionRepository.flush();
+
+            broadcastSessionEnded(sessionCode);
+        }
+
         System.out.println("Votes received for movie " + votePutDTO.getMovieId() + ": " + votesReceived);
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -193,9 +193,10 @@ public class SessionService {
                 throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Guest user not found");
             }
             expectedId = guestUser.getId();
-            
+
             // Remove from session
-            if (guestUser.getCurrentSession() != null && guestUser.getCurrentSession().getSessionId().equals(session.getSessionId())) {
+            if (guestUser.getCurrentSession() != null
+                    && guestUser.getCurrentSession().getSessionId().equals(session.getSessionId())) {
                 guestUser.setCurrentSession(null);
                 guestUserRepository.save(guestUser);
                 guestUserRepository.flush();
@@ -206,9 +207,10 @@ public class SessionService {
                 throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found");
             }
             expectedId = user.getId();
-            
+
             // Remove from session
-            if (user.getCurrentSession() != null && user.getCurrentSession().getSessionId().equals(session.getSessionId())) {
+            if (user.getCurrentSession() != null
+                    && user.getCurrentSession().getSessionId().equals(session.getSessionId())) {
                 user.setCurrentSession(null);
                 userRepository.save(user);
                 userRepository.flush();
@@ -257,7 +259,8 @@ public class SessionService {
 
     private void broadcastVoteProgress(String sessionCode, Integer votesReceived, Integer joinedUsers) {
         Map<String, Object> voteProgressPayload = new HashMap<>();
-        //added ternary checks to avoid null values, should not occur but better safe than sorry
+        // added ternary checks to avoid null values, should not occur but better safe
+        // than sorry
         voteProgressPayload.put("votesReceived", votesReceived == null ? 0 : votesReceived);
         voteProgressPayload.put("joinedUsers", joinedUsers == null ? 0 : joinedUsers);
         messagingTemplate.convertAndSend((topic(sessionCode) + "/vote-progress"), (Object) voteProgressPayload);
@@ -292,6 +295,37 @@ public class SessionService {
         // getNextMovie(sessionCode);
     }
 
+    public Movie forceNextMovie(String sessionCode, String token) {
+        Session session = sessionRepository.findSessionBySessionCode(sessionCode);
+        if (session == null)
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Session not found");
+
+        // 1. Correct Host Validation
+        Long currentUserId = null;
+        User user = userRepository.findByToken(token);
+        GuestUser guestUser = guestUserRepository.findByToken(token);
+
+        if (user != null)
+            currentUserId = user.getId();
+        else if (guestUser != null)
+            currentUserId = guestUser.getId();
+
+        if (currentUserId == null || !currentUserId.equals(session.getHostId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only the host can force the next movie");
+        }
+
+        Integer actualVotes = session.getVotesReceivedThisRound();
+
+        Integer joinedUsers = session.getJoinedUsers();
+
+        if (joinedUsers != null && actualVotes < joinedUsers) {
+            System.out.println("DB Votes: " + actualVotes + " Joined: " + joinedUsers);
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Not all users have voted yet");
+        }
+
+        return getNextMovie(sessionCode);
+    }
+
     @Transactional
     public Movie getNextMovie(String sessionCode) {
         Session session = sessionRepository.findSessionBySessionCode(sessionCode);
@@ -324,8 +358,8 @@ public class SessionService {
         sessionRepository.save(session);
         sessionRepository.flush();
 
-        //broadcast movie details to all users
-        broadcastVoteProgress(sessionCode, 0, session.getJoinedUsers()); 
+        // broadcast movie details to all users
+        broadcastVoteProgress(sessionCode, 0, session.getJoinedUsers());
 
         // This sends the movie object to everyone subscribed to that session's topic
 
@@ -337,7 +371,8 @@ public class SessionService {
         return movie;
     }
 
-    // this method is needed for correct redirection because of timing issues with the websocket
+    // this method is needed for correct redirection because of timing issues with
+    // the websocket
     public Movie getCurrentMovie(String sessionCode) {
         Session session = sessionRepository.findSessionBySessionCode(sessionCode);
 
@@ -441,28 +476,18 @@ public class SessionService {
         }
 
         Integer votesReceived = voteRepository
-            .countBySessionCodeAndMovieId(votePutDTO.getSessionCode(), votePutDTO.getMovieId())
-            .intValue();
+                .countBySessionCodeAndMovieId(votePutDTO.getSessionCode(), votePutDTO.getMovieId())
+                .intValue();
         session.setVotesReceivedThisRound(votesReceived);
         sessionRepository.save(session);
         sessionRepository.flush();
-    
+
         broadcastVoteProgress(
                 votePutDTO.getSessionCode(),
                 votesReceived,
                 session.getJoinedUsers());
 
-        Integer joinedUsers = session.getJoinedUsers();
-
-        if (joinedUsers != null && votesReceived >= joinedUsers) {
-            // All users have voted - proceed to next movie
-            session.setVotesReceivedThisRound(0); // Reset for next round
-            sessionRepository.save(session);
-            sessionRepository.flush();
-
-            broadcastVoteProgress(votePutDTO.getSessionCode(), 0, session.getJoinedUsers());
-            advanceOrEndSession(votePutDTO.getSessionCode());
-        }
+        System.out.println("Votes received for movie " + votePutDTO.getMovieId() + ": " + votesReceived);
     }
 
     public List<MovieResultDTO> calculateFullLeaderboard(String sessionCode) {
@@ -482,12 +507,11 @@ public class SessionService {
             Integer summedScore = voteRepository.getSumOfScores(sessionCode, movieId);
             int score = summedScore != null ? summedScore : 0;
 
-            List<SimilarMovieGetDTO> similarMovieDTOs =
-                    movie.getSimilarMovies() == null
-                            ? List.of()
-                            : movie.getSimilarMovies().stream()
-                                    .map(ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper.INSTANCE::convertSimilarMovieToDTO)
-                                    .toList();
+            List<SimilarMovieGetDTO> similarMovieDTOs = movie.getSimilarMovies() == null
+                    ? List.of()
+                    : movie.getSimilarMovies().stream()
+                            .map(ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper.INSTANCE::convertSimilarMovieToDTO)
+                            .toList();
 
             MovieResultDTO dto = new MovieResultDTO(
                     movie.getId(),

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SessionControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SessionControllerTest.java
@@ -50,6 +50,8 @@ class SessionControllerTest {
 
         private Session testSession;
 
+        private Movie testMovie;
+
         @BeforeEach
         void setup() {
                 // Initialize the object once for all tests
@@ -64,6 +66,21 @@ class SessionControllerTest {
                 testSession.setStatus(SessionStatus.ONLINE);
                 testSession.setCreationDate(new java.util.Date());
                 testSession.setSessionToken("testSessionToken");
+
+                testMovie = new Movie(
+                                550L,
+                                "Fight Club",
+                                "Insomnia and soap.",
+                                "https://image.tmdb.org/t/p/w500/fight-club.jpg",
+                                8.4,
+                                "1999-10-15",
+                                List.of("Drama", "Thriller"),
+                                List.of(new SimilarMovie(
+                                                551L,
+                                                "Se7en",
+                                                "https://image.tmdb.org/t/p/w500/se7en.jpg",
+                                                8.3,
+                                                "1995-09-22")));
         }
 
         // When creating new Session correct Session Credentials get returned and Status
@@ -155,22 +172,8 @@ class SessionControllerTest {
 
         @Test
         void getNextMovie_validSessionCode_returnsMovie() throws Exception {
-                Movie movie = new Movie(
-                                550L,
-                                "Fight Club",
-                                "Insomnia and soap.",
-                                "https://image.tmdb.org/t/p/w500/fight-club.jpg",
-                                8.4,
-                                "1999-10-15",
-                                List.of("Drama", "Thriller"),
-                                List.of(new SimilarMovie(
-                                                551L,
-                                                "Se7en",
-                                                "https://image.tmdb.org/t/p/w500/se7en.jpg",
-                                                8.3,
-                                                "1995-09-22")));
 
-                given(sessionService.getNextMovie("1")).willReturn(movie);
+                given(sessionService.getNextMovie("1")).willReturn(testMovie);
 
                 MockHttpServletRequestBuilder getRequest = get("/session/1/next")
                                 .contentType(MediaType.APPLICATION_JSON);
@@ -262,39 +265,38 @@ class SessionControllerTest {
         @Test
         void getSessionResults_validSessionCode_returnsDetailedResults() throws Exception {
                 MovieResultDTO dto = new MovieResultDTO(
-                        550L,
-                        "Fight Club",
-                        8,
-                        "https://someImagetoMovie.jpg",
-                        "Insomnia and soap.",
-                        8.4,
-                        "1999-10-15",
-                        List.of("Drama", "Thriller"),
-                        List.of(),
-                        5,
-                        1,
-                        2
-                );
+                                550L,
+                                "Fight Club",
+                                8,
+                                "https://someImagetoMovie.jpg",
+                                "Insomnia and soap.",
+                                8.4,
+                                "1999-10-15",
+                                List.of("Drama", "Thriller"),
+                                List.of(),
+                                5,
+                                1,
+                                2);
 
                 given(sessionService.calculateFullLeaderboard("test1234")).willReturn(List.of(dto));
 
                 MockHttpServletRequestBuilder getRequest = get("/session/test1234/results")
-                        .contentType(MediaType.APPLICATION_JSON);
+                                .contentType(MediaType.APPLICATION_JSON);
 
                 mockMvc.perform(getRequest)
-                        .andExpect(status().isOk())
-                        .andExpect(jsonPath("$", hasSize(1)))
-                        .andExpect(jsonPath("$[0].movieId", is(550)))
-                        .andExpect(jsonPath("$[0].title", is("Fight Club")))
-                        .andExpect(jsonPath("$[0].score", is(8)))
-                        .andExpect(jsonPath("$[0].posterPath", is("https://someImagetoMovie.jpg")))
-                        .andExpect(jsonPath("$[0].description", is("Insomnia and soap.")))
-                        .andExpect(jsonPath("$[0].rating", is(8.4)))
-                        .andExpect(jsonPath("$[0].releaseDate", is("1999-10-15")))
-                        .andExpect(jsonPath("$[0].genres", hasSize(2)))
-                        .andExpect(jsonPath("$[0].likes", is(5)))
-                        .andExpect(jsonPath("$[0].dislikes", is(1)))
-                        .andExpect(jsonPath("$[0].neutrals", is(2)));
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$", hasSize(1)))
+                                .andExpect(jsonPath("$[0].movieId", is(550)))
+                                .andExpect(jsonPath("$[0].title", is("Fight Club")))
+                                .andExpect(jsonPath("$[0].score", is(8)))
+                                .andExpect(jsonPath("$[0].posterPath", is("https://someImagetoMovie.jpg")))
+                                .andExpect(jsonPath("$[0].description", is("Insomnia and soap.")))
+                                .andExpect(jsonPath("$[0].rating", is(8.4)))
+                                .andExpect(jsonPath("$[0].releaseDate", is("1999-10-15")))
+                                .andExpect(jsonPath("$[0].genres", hasSize(2)))
+                                .andExpect(jsonPath("$[0].likes", is(5)))
+                                .andExpect(jsonPath("$[0].dislikes", is(1)))
+                                .andExpect(jsonPath("$[0].neutrals", is(2)));
         }
 
         @Test
@@ -313,69 +315,55 @@ class SessionControllerTest {
 
         @Test
         void getSessionTime_validSessionCode_returnsOk() throws Exception {
-            given(sessionService.getSessionTiming("test123")).willReturn(30);
+                given(sessionService.getSessionTiming("test123")).willReturn(30);
 
-            MockHttpServletRequestBuilder getRequest = get("/session/test123/time")
-                    .contentType(MediaType.APPLICATION_JSON);
+                MockHttpServletRequestBuilder getRequest = get("/session/test123/time")
+                                .contentType(MediaType.APPLICATION_JSON);
 
-            mockMvc.perform(getRequest)
-                    .andExpect(status().isOk())
-                    .andExpect(content().string("30"));
+                mockMvc.perform(getRequest)
+                                .andExpect(status().isOk())
+                                .andExpect(content().string("30"));
         }
 
         @Test
         void getCurrentMovie_validSessionCode_returnsMovie() throws Exception {
-                Movie movie = new Movie(
-                550L,
-                "Fight Club",
-                "Insomnia and soap.",
-                "https://image.tmdb.org/t/p/w500/fight-club.jpg",
-                8.4,
-                "1999-10-15",
-                List.of("Drama", "Thriller"),
-                List.of(new SimilarMovie(
-                551L,
-                "Se7en",
-                "https://image.tmdb.org/t/p/w500/se7en.jpg",
-                8.3,
-                "1995-09-22")));
 
-                given(sessionService.getCurrentMovie("1")).willReturn(movie);
+                given(sessionService.getCurrentMovie("1")).willReturn(testMovie);
 
                 MockHttpServletRequestBuilder getRequest = get("/session/1/current")
-                .contentType(MediaType.APPLICATION_JSON);
+                                .contentType(MediaType.APPLICATION_JSON);
 
                 mockMvc.perform(getRequest)
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.movieId", is(550)))
-                .andExpect(jsonPath("$.title", is("Fight Club")))
-                .andExpect(jsonPath("$.description", is("Insomnia and soap.")));
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.movieId", is(550)))
+                                .andExpect(jsonPath("$.title", is("Fight Club")))
+                                .andExpect(jsonPath("$.description", is("Insomnia and soap.")));
         }
 
         @Test
         void getCurrentMovie_invalidSessionCode_returnsNotFound() throws Exception {
                 given(sessionService.getCurrentMovie("404"))
-                .willThrow(new ResponseStatusException(HttpStatus.NOT_FOUND,
-                "Session could not be found."));
+                                .willThrow(new ResponseStatusException(HttpStatus.NOT_FOUND,
+                                                "Session could not be found."));
 
                 MockHttpServletRequestBuilder getRequest = get("/session/404/current")
-                .contentType(MediaType.APPLICATION_JSON);
+                                .contentType(MediaType.APPLICATION_JSON);
 
                 mockMvc.perform(getRequest)
-                .andExpect(status().isNotFound());
+                                .andExpect(status().isNotFound());
         }
 
         @Test
         void getCurrentMovie_notStarted_returnsConflict() throws Exception {
                 given(sessionService.getCurrentMovie("nostart"))
-                .willThrow(new ResponseStatusException(HttpStatus.CONFLICT,
-                "Session has not started yet"));
+                                .willThrow(new ResponseStatusException(HttpStatus.CONFLICT,
+                                                "Session has not started yet"));
 
                 MockHttpServletRequestBuilder getRequest = get("/session/nostart/current")
-                .contentType(MediaType.APPLICATION_JSON);
+                                .contentType(MediaType.APPLICATION_JSON);
 
                 mockMvc.perform(getRequest)
-                .andExpect(status().isConflict());
+                                .andExpect(status().isConflict());
         }
 
         @Test
@@ -383,7 +371,29 @@ class SessionControllerTest {
                 Mockito.doNothing().when(sessionService).leaveSession("test1234", "userToken");
 
                 mockMvc.perform(delete("/session/test1234")
-                        .header("Authorization", "userToken"))
-                        .andExpect(status().isNoContent());
+                                .header("Authorization", "userToken"))
+                                .andExpect(status().isNoContent());
+        }
+
+        @Test
+        void skipTimer_allUsersVoted_returnsOk() throws Exception {
+
+                Mockito.when(sessionService.forceNextMovie(Mockito.anyString(), Mockito.anyString()))
+                                .thenReturn(testMovie);
+
+                mockMvc.perform(post("/session/test1234/next/request")
+                                .header("Authorization", "userToken"))
+                                .andExpect(status().isOk());
+        }
+
+        @Test
+        void skipTimer_invalidSessionCode_returnsNotFound() throws Exception {
+                Mockito.doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND,
+                                "Session could not be found."))
+                                .when(sessionService).forceNextMovie("1234", "userToken");
+
+                mockMvc.perform(post("/session/1234/next/request")
+                                .header("Authorization", "userToken"))
+                                .andExpect(status().isNotFound());
         }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
@@ -62,9 +62,12 @@ class SessionServiceTest {
 
         private User testUser;
         private GuestUser testGuest;
+        private Movie testMovie;
+        private String sessionCode;
 
         @BeforeEach
         void setup() {
+                token = "randomToken";
                 testSession = new Session();
                 testSession.setSessionName("testSession");
                 testSession.setMaxPlayers(5);
@@ -77,7 +80,22 @@ class SessionServiceTest {
                 testGuest = new GuestUser();
                 testGuest.setId(1L);
 
-                token = "randomToken";
+                sessionCode = "ABCDE";
+
+                testMovie = new Movie(
+                                550L,
+                                "Fight Club",
+                                "Insomnia and soap.",
+                                "https://image.tmdb.org/t/p/w500/fight-club.jpg",
+                                8.4,
+                                "1999-10-15",
+                                List.of("Drama", "Thriller"),
+                                List.of(new SimilarMovie(
+                                                551L,
+                                                "Se7en",
+                                                "https://image.tmdb.org/t/p/w500/se7en.jpg",
+                                                8.3,
+                                                "1995-09-22")));
         }
 
         @Test
@@ -801,6 +819,31 @@ class SessionServiceTest {
                 verify(voteRepository).save(existing);
         }
 
+        @Test
+        void forceNextMovie_validHost_returnsNextMovie() {
+                testSession.setSessionMovieIds(List.of(550L));
+                testSession.setCurrentMovieIndex(0);
+                testSession.setVotesReceivedThisRound(0);
+                testSession.setJoinedUsers(null);
+
+                testUser.setId(1L);
+
+                Mockito.when(sessionRepository.findSessionBySessionCode(sessionCode))
+                                .thenReturn(testSession);
+                Mockito.when(userRepository.findByToken(token))
+                                .thenReturn(testUser);
+                Mockito.when(tmdbService.getMovieDetails(550L))
+                                .thenReturn(testMovie);
+                Mockito.doNothing().when(messagingTemplate)
+                                .convertAndSend(Mockito.anyString(), Mockito.<Object>any());
+                Mockito.when(sessionRepository.save(Mockito.any(Session.class)))
+                                .thenAnswer(i -> i.getArgument(0));
+
+                Movie result = sessionService.forceNextMovie(sessionCode, token);
+
+                assertEquals(testMovie, result);
+        }
+
         /**
          * Tests will be reactivated if fix is found for the corresponding function
          * 
@@ -907,84 +950,28 @@ class SessionServiceTest {
          *       }
          * 
          **/
-
         @Test
-        void vote_allUsersVoted_invalidMovieIndex_throwsConflict() {
+        void getNextMovie_invalidMovieIndex_throwsConflict() {
                 Session session = new Session();
                 session.setSessionId(1L);
                 session.setSessionCode("ABCDE");
                 session.setSessionMovieIds(List.of(55L, 66L));
                 session.setCurrentMovieIndex(-1);
                 session.setJoinedUsers(2);
-                session.setVotesReceivedThisRound(0);
-
-                User user = new User();
-                user.setId(1L);
-                user.setCurrentSession(session);
-
-                VotePutDTO dto = new VotePutDTO();
-                dto.setSessionCode("ABCDE");
-                dto.setToken("token");
-                dto.setMovieId(55L);
-                dto.setUserId(1L);
-                dto.setScore(1);
 
                 Mockito.when(sessionRepository.findSessionBySessionCode("ABCDE")).thenReturn(session);
                 Mockito.when(sessionRepository.save(Mockito.any(Session.class)))
                                 .thenAnswer(invocation -> invocation.getArgument(0));
-                Mockito.when(userRepository.findByToken("token")).thenReturn(user);
-                Mockito.when(voteRepository.findBySessionCodeAndUserIdAndMovieId("ABCDE", 1L, 55L))
-                                .thenReturn(null);
-                Mockito.when(voteRepository.countBySessionCodeAndMovieId("ABCDE", 55L)).thenReturn(2L);
 
                 ResponseStatusException exception = assertThrows(
                                 ResponseStatusException.class,
-                                () -> sessionService.setVote(dto));
+                                () -> sessionService.getNextMovie("ABCDE"));
 
                 assertEquals(409, exception.getStatusCode().value());
-                assertEquals("Invalid movie index", exception.getReason());
-                verify(messagingTemplate, Mockito.times(2)).convertAndSend(
-                                Mockito.eq("/topic/session/ABCDE/vote-progress"),
+                assertEquals("No more movies available in this session", exception.getReason());
+                verify(messagingTemplate, Mockito.times(1)).convertAndSend(
+                                Mockito.eq("/topic/session/ABCDE/end"),
                                 Mockito.any(Object.class));
         }
 
-        @Test
-        void vote_allUsersVoted_noMoviesAssigned_throwsConflict() {
-                Session session = new Session();
-                session.setSessionId(1L);
-                session.setSessionCode("ABCDE");
-                session.setSessionMovieIds(List.of());
-                session.setCurrentMovieIndex(0);
-                session.setJoinedUsers(1);
-                session.setVotesReceivedThisRound(0);
-
-                User user = new User();
-                user.setId(1L);
-                user.setCurrentSession(session);
-
-                VotePutDTO dto = new VotePutDTO();
-                dto.setSessionCode("ABCDE");
-                dto.setToken("token");
-                dto.setMovieId(55L);
-                dto.setUserId(1L);
-                dto.setScore(1);
-
-                Mockito.when(sessionRepository.findSessionBySessionCode("ABCDE")).thenReturn(session);
-                Mockito.when(sessionRepository.save(Mockito.any(Session.class)))
-                                .thenAnswer(invocation -> invocation.getArgument(0));
-                Mockito.when(userRepository.findByToken("token")).thenReturn(user);
-                Mockito.when(voteRepository.findBySessionCodeAndUserIdAndMovieId("ABCDE", 1L, 55L))
-                                .thenReturn(null);
-                Mockito.when(voteRepository.countBySessionCodeAndMovieId("ABCDE", 55L)).thenReturn(1L);
-
-                ResponseStatusException exception = assertThrows(
-                                ResponseStatusException.class,
-                                () -> sessionService.setVote(dto));
-
-                assertEquals(409, exception.getStatusCode().value());
-                assertEquals("Session has no movies assigned", exception.getReason());
-                verify(messagingTemplate, Mockito.times(2)).convertAndSend(
-                                Mockito.eq("/topic/session/ABCDE/vote-progress"),
-                                Mockito.any(Object.class));
-        }
 }


### PR DESCRIPTION
This development task closes #208 in order to enable the host to skip the timer in case all users have already voted. More specifically the following tasks were done:

- a new endpoint POST /next/request was created
- the host can fetch this endpoint and thus skip the timer
- additional test cases were written
- (in a fourth commit two unnecessary print statements were deleted to ensure clean code)