### PR TITLE
Back end support for user tags in lobby

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SessionController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SessionController.java
@@ -36,6 +36,7 @@ public class SessionController {
 
         SessionGetDTO dto = DTOMapper.INSTANCE.convertEntitytoSessionGetDTO(createdSession);
         dto.setUsernames(sessionService.getJoinedUsernames(createdSession));
+        dto.setHostUsername(sessionService.getHostUsername(createdSession));
         return dto;
     }
 
@@ -47,6 +48,7 @@ public class SessionController {
 
         SessionGetDTO dto = DTOMapper.INSTANCE.convertEntitytoSessionGetDTO(session);
         dto.setUsernames(sessionService.getJoinedUsernames(session));
+        dto.setHostUsername(sessionService.getHostUsername(session));
         return dto;
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SessionGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SessionGetDTO.java
@@ -65,4 +65,14 @@ public class SessionGetDTO {
     public void setUsernames(List<String> usernames) {
         this.usernames = usernames;
     }
+
+    private String hostUsername;
+
+    public String getHostUsername() {
+        return hostUsername;
+    }
+
+    public void setHostUsername(String hostUsername) {
+        this.hostUsername = hostUsername;
+    }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -169,6 +169,7 @@ public class SessionService {
         lobbyUpdate.put("joinedUsers", session.getJoinedUsers());
         lobbyUpdate.put("maxPlayers", session.getMaxPlayers());
         lobbyUpdate.put("usernames", getJoinedUsernames(session));
+        lobbyUpdate.put("hostUsername", getHostUsername(session));
 
         // updated number of users who have already joined the session
         messagingTemplate.convertAndSend((topic(sessionCode) + "/lobby"), (Object) lobbyUpdate);
@@ -234,6 +235,7 @@ public class SessionService {
             lobbyUpdate.put("joinedUsers", session.getJoinedUsers());
             lobbyUpdate.put("maxPlayers", session.getMaxPlayers());
             lobbyUpdate.put("usernames", getJoinedUsernames(session));
+            lobbyUpdate.put("hostUsername", getHostUsername(session));
 
             messagingTemplate.convertAndSend((topic(sessionCode) + "/lobby"), (Object) lobbyUpdate);
         }
@@ -571,6 +573,19 @@ public class SessionService {
             usernames.add(guest.getUsername());
         }
         return usernames;
+    }
+
+    public String getHostUsername(Session session) {
+        Long hostId = session.getHostId();
+        if (hostId == null) return null;
+
+        User user = userRepository.findById(hostId).orElse(null);
+        if (user != null) return user.getUsername();
+
+        GuestUser guest = guestUserRepository.findById(hostId).orElse(null);
+        if (guest != null) return guest.getUsername();
+
+        return null;
     }
 
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SessionControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SessionControllerTest.java
@@ -96,6 +96,9 @@ class SessionControllerTest {
                 sessionPostDTO.setHostId(1L);
 
                 given(sessionService.createSession(Mockito.any(), Mockito.any())).willReturn(testSession);
+                given(sessionService.getJoinedUsernames(Mockito.any())).willReturn(List.of("hostUser"));
+                given(sessionService.getHostUsername(Mockito.any())).willReturn("hostUser");
+
                 MockHttpServletRequestBuilder postRequest = post("/session")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(asJsonString(sessionPostDTO));
@@ -104,7 +107,8 @@ class SessionControllerTest {
                                 .andExpect(status().isCreated())
                                 .andExpect(jsonPath("$.sessionCode", is(testSession.getSessionCode())))
                                 .andExpect(jsonPath("$.sessionId", is(testSession.getSessionId().intValue())))
-                                .andExpect(jsonPath("$.sessionToken", is(testSession.getSessionToken())));
+                                .andExpect(jsonPath("$.sessionToken", is(testSession.getSessionToken())))
+                                .andExpect(jsonPath("$.hostUsername", is("hostUser")));
 
         }
 
@@ -134,6 +138,8 @@ class SessionControllerTest {
         void joinSession_validSessionCode_getSuccessful() throws Exception {
 
                 given(sessionService.joinSession(anyString(), any(SessionPutDTO.class))).willReturn(testSession);
+                given(sessionService.getJoinedUsernames(Mockito.any())).willReturn(List.of("hostUser", "joiner"));
+                given(sessionService.getHostUsername(Mockito.any())).willReturn("hostUser");
 
                 SessionPutDTO sessionPutDTO = new SessionPutDTO();
                 sessionPutDTO.setToken("userToken");
@@ -147,7 +153,8 @@ class SessionControllerTest {
                                 .andExpect(status().isOk())
                                 .andExpect(jsonPath("$.sessionCode", is(testSession.getSessionCode())))
                                 .andExpect(jsonPath("$.sessionId", is(1)))
-                                .andExpect(jsonPath("$.sessionToken", is(testSession.getSessionToken())));
+                                .andExpect(jsonPath("$.sessionToken", is(testSession.getSessionToken())))
+                                .andExpect(jsonPath("$.hostUsername", is("hostUser")));
         }
 
         // Getting a session for joining not successfully

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
@@ -846,4 +846,50 @@ class SessionServiceTest {
                                 Mockito.any(Object.class));
         }
 
+        @Test
+        void getHostUsername_hostIsUser_returnsUsername() {
+                testSession.setHostId(1L);
+
+                testUser.setUsername("hostUser");
+                Mockito.when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+
+                String result = sessionService.getHostUsername(testSession);
+
+                assertEquals("hostUser", result);
+        }
+
+        @Test
+        void getHostUsername_hostIsGuest_returnsUsername() {
+                testSession.setHostId(1L);
+
+                testGuest.setUsername("guestHost");
+                Mockito.when(userRepository.findById(1L)).thenReturn(Optional.empty());
+                Mockito.when(guestUserRepository.findById(1L)).thenReturn(Optional.of(testGuest));
+
+                String result = sessionService.getHostUsername(testSession);
+
+                assertEquals("guestHost", result);
+        }
+
+        @Test
+        void getHostUsername_hostIdIsNull_returnsNull() {
+                testSession.setHostId(null);
+
+                String result = sessionService.getHostUsername(testSession);
+
+                assertNull(result);
+        }
+
+        @Test
+        void getHostUsername_hostNotFound_returnsNull() {
+                testSession.setHostId(99L);
+
+                Mockito.when(userRepository.findById(99L)).thenReturn(Optional.empty());
+                Mockito.when(guestUserRepository.findById(99L)).thenReturn(Optional.empty());
+
+                String result = sessionService.getHostUsername(testSession);
+
+                assertNull(result);
+        }
+
 }


### PR DESCRIPTION
Back end portion of front end issue 158. 

added a getHostUsername() method in SessionService that resolves the session's hostId to a username by looking up both the User and GuestUser tables. This value is then included in the REST responses (SessionGetDTO) and WebSocket lobby broadcasts, so the frontend can match the host's name against the joined users list to display the (Host) tag.