### PR TITLE
Added votedeletion to the SessionCleanupService

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/SessionRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/SessionRepository.java
@@ -1,6 +1,5 @@
 package ch.uzh.ifi.hase.soprafs26.repository;
 
-import ch.uzh.ifi.hase.soprafs26.constant.SessionStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.Session;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -19,7 +18,7 @@ public interface SessionRepository extends JpaRepository<Session, Long> {
 
     Session findSessionBySessionCode(String sessionCode);
 
-    List<Session> findByStatusAndExpiresAtBefore(SessionStatus status, Instant now);
+    List<Session> findByExpiresAtBefore(Instant now);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("""

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/VoteRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/VoteRepository.java
@@ -27,4 +27,6 @@ public interface VoteRepository extends JpaRepository<Vote, Long> {
     Long countBySessionCodeAndMovieIdAndScore(@Param("sessionCode") String sessionCode, @Param("movieId") Long movieId, @Param("score") Integer score);
 
     List<Vote> findBySessionCodeAndMovieIdAndUserIdIn(String sessionCode, Long movieId, List<Long> userIds);
+
+    void deleteBySessionCode(String sessionCode);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionCleanupService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionCleanupService.java
@@ -1,10 +1,10 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
-import ch.uzh.ifi.hase.soprafs26.constant.SessionStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.Session;
 import ch.uzh.ifi.hase.soprafs26.repository.GuestUserRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.SessionRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.VoteRepository;
 import jakarta.transaction.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,18 +22,20 @@ public class SessionCleanupService {
     private final SessionRepository sessionRepository;
     private final UserRepository userRepository;
     private final GuestUserRepository guestUserRepository;
+    private final VoteRepository voteRepository;
 
     public SessionCleanupService(SessionRepository sessionRepository,
                                  UserRepository userRepository,
-                                 GuestUserRepository guestUserRepository) {
+                                 GuestUserRepository guestUserRepository, VoteRepository voteRepository) {
         this.sessionRepository = sessionRepository;
         this.userRepository = userRepository;
         this.guestUserRepository = guestUserRepository;
+        this.voteRepository = voteRepository;
     }
 
     @Scheduled(fixedRate = 300000)
     public void cleanupSessions() {
-        List<Session> expired = sessionRepository.findByStatusAndExpiresAtBefore(SessionStatus.OFFLINE, Instant.now());
+        List<Session> expired = sessionRepository.findByExpiresAtBefore(Instant.now());
 
         if (expired.isEmpty()) {
             return;
@@ -43,12 +45,19 @@ public class SessionCleanupService {
                 .map(Session::getSessionId)
                 .toList();
 
+        List<String> codes = expired.stream()
+                .map(Session::getSessionCode)
+                .toList();
+
         int usersUnlinked = userRepository.unlinkUsersFromSessions(ids);
         int guestUnlinked = guestUserRepository.unlinkGuestUsersFromSessions(ids);
 
         log.debug("Unlinked {} Users and Guest Users from sessions", usersUnlinked + guestUnlinked);
 
         sessionRepository.deleteAll(expired);
+        for (String code : codes) {
+            voteRepository.deleteBySessionCode(code);
+        }
         log.debug("Cleaned up {} expired sessions", ids.size());
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionCleanupServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionCleanupServiceTest.java
@@ -1,10 +1,10 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
-import ch.uzh.ifi.hase.soprafs26.constant.SessionStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.Session;
 import ch.uzh.ifi.hase.soprafs26.repository.GuestUserRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.SessionRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.VoteRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,7 +16,6 @@ import java.time.Instant;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
@@ -32,6 +31,9 @@ class SessionCleanupServiceTest {
     @Mock
     private GuestUserRepository guestUserRepository;
 
+    @Mock
+    private VoteRepository voteRepository;
+
     private SessionCleanupService sessionCleanupService;
 
     @BeforeEach
@@ -39,13 +41,14 @@ class SessionCleanupServiceTest {
         sessionCleanupService = new SessionCleanupService(
                 sessionRepository,
                 userRepository,
-                guestUserRepository
+                guestUserRepository,
+                voteRepository
         );
     }
 
     @Test
     void cleanupSessions_whenNoExpiredSessions_doesNothing() {
-        Mockito.when(sessionRepository.findByStatusAndExpiresAtBefore(eq(SessionStatus.OFFLINE), any(Instant.class)))
+        Mockito.when(sessionRepository.findByExpiresAtBefore(any(Instant.class)))
                 .thenReturn(List.of());
 
         sessionCleanupService.cleanupSessions();
@@ -66,7 +69,7 @@ class SessionCleanupServiceTest {
         List<Session> expiredSessions = List.of(session1, session2);
         List<Long> sessionIds = List.of(1L, 2L);
 
-        Mockito.when(sessionRepository.findByStatusAndExpiresAtBefore(eq(SessionStatus.OFFLINE), any(Instant.class)))
+        Mockito.when(sessionRepository.findByExpiresAtBefore(any(Instant.class)))
                 .thenReturn(expiredSessions);
         Mockito.when(userRepository.unlinkUsersFromSessions(sessionIds)).thenReturn(2);
         Mockito.when(guestUserRepository.unlinkGuestUsersFromSessions(sessionIds)).thenReturn(1);


### PR DESCRIPTION
Sessions left prematurely were never deleted, fixed that by only relying on expiresAt instead of that and status.

Votes were not automatically deleted, so added that too