### PR TITLE
Jaltma fix

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SessionController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SessionController.java
@@ -38,6 +38,7 @@ public class SessionController {
 
         SessionGetDTO dto = DTOMapper.INSTANCE.convertEntitytoSessionGetDTO(createdSession);
         dto.setUsernames(sessionService.getJoinedUsernames(createdSession));
+        dto.setHostUsername(sessionService.getHostUsername(createdSession));
         return dto;
     }
 
@@ -49,6 +50,7 @@ public class SessionController {
 
         SessionGetDTO dto = DTOMapper.INSTANCE.convertEntitytoSessionGetDTO(session);
         dto.setUsernames(sessionService.getJoinedUsernames(session));
+        dto.setHostUsername(sessionService.getHostUsername(session));
         return dto;
     }
 
@@ -137,6 +139,7 @@ public class SessionController {
 
         SessionStatusGetDTO dto = DTOMapper.INSTANCE.convertEntitytoSessionStatusGetDTO(session);
         dto.setUsernames(sessionService.getJoinedUsernames(session));
+        dto.setHostUsername(sessionService.getHostUsername(session));
         return dto;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SessionGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SessionGetDTO.java
@@ -9,6 +9,7 @@ public class SessionGetDTO {
     private long hostId;
     private Integer joinedUsers;
     private List<String> usernames;
+    private String hostUsername;
 
     public String getSessionName() {
         return sessionName;
@@ -64,5 +65,13 @@ public class SessionGetDTO {
 
     public void setUsernames(List<String> usernames) {
         this.usernames = usernames;
+    }
+
+    public String getHostUsername() {
+        return hostUsername;
+    }
+
+    public void setHostUsername(String hostUsername) {
+        this.hostUsername = hostUsername;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SessionStateGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SessionStateGetDTO.java
@@ -14,6 +14,7 @@ public class SessionStateGetDTO {
     private Integer votesReceived;
     private Integer totalRounds;
     private List<String> usernames;
+    private String hostUsername;
 
     public String getSessionCode() {
         return sessionCode;
@@ -93,5 +94,13 @@ public class SessionStateGetDTO {
 
     public void setUsernames(List<String> usernames) {
         this.usernames = usernames;
+    }
+
+    public String getHostUsername() {
+        return hostUsername;
+    }
+
+    public void setHostUsername(String hostUsername) {
+        this.hostUsername = hostUsername;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SessionStatusGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SessionStatusGetDTO.java
@@ -6,6 +6,7 @@ public class SessionStatusGetDTO {
     private Integer maxPlayers;
     private Integer joinedUsers;
     private List<String> usernames;
+    private String hostUsername;
 
     public Integer getMaxPlayers() {
         return maxPlayers;
@@ -29,6 +30,14 @@ public class SessionStatusGetDTO {
 
     public void setUsernames(List<String> usernames) {
         this.usernames = usernames;
+    }
+
+    public String getHostUsername() {
+        return hostUsername;
+    }
+
+    public void setHostUsername(String hostUsername) {
+        this.hostUsername = hostUsername;
     }
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -446,6 +446,7 @@ public class SessionService {
         dto.setVotesReceived(session.getVotesReceivedThisRound());
         dto.setTotalRounds(session.getRoundLimit());
         dto.setUsernames(getJoinedUsernames(session));
+        dto.setHostUsername(getHostUsername(session));
 
         Movie currentMovie = tryGetCurrentMovie(session);
         if (currentMovie != null) {
@@ -696,6 +697,25 @@ public class SessionService {
             usernames.add(guest.getUsername());
         }
         return usernames;
+    }
+
+    public String getHostUsername(Session session) {
+        Long hostId = session.getHostId();
+        if (hostId == null) {
+            return null;
+        }
+
+        User user = userRepository.findById(hostId).orElse(null);
+        if (user != null) {
+            return user.getUsername();
+        }
+
+        GuestUser guestUser = guestUserRepository.findById(hostId).orElse(null);
+        if (guestUser != null) {
+            return guestUser.getUsername();
+        }
+
+        return null;
     }
 
     private int refreshJoinedUsers(Session session) {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SessionControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SessionControllerTest.java
@@ -99,6 +99,8 @@ class SessionControllerTest {
                 sessionPostDTO.setHostId(1L);
 
                 given(sessionService.createSession(Mockito.any(), Mockito.any())).willReturn(testSession);
+                given(sessionService.getJoinedUsernames(Mockito.any())).willReturn(List.of("HostUser"));
+                given(sessionService.getHostUsername(Mockito.any())).willReturn("HostUser");
                 MockHttpServletRequestBuilder postRequest = post("/session")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(asJsonString(sessionPostDTO));
@@ -107,8 +109,8 @@ class SessionControllerTest {
                                 .andExpect(status().isCreated())
                                 .andExpect(jsonPath("$.sessionCode", is(testSession.getSessionCode())))
                                 .andExpect(jsonPath("$.sessionId", is(testSession.getSessionId().intValue())))
-                                .andExpect(jsonPath("$.sessionToken", is(testSession.getSessionToken())));
-
+                                .andExpect(jsonPath("$.sessionToken", is(testSession.getSessionToken())))
+                                .andExpect(jsonPath("$.hostUsername", is("HostUser")));
         }
 
         // Session Creation not successful
@@ -137,6 +139,8 @@ class SessionControllerTest {
         void joinSession_validSessionCode_getSuccessful() throws Exception {
 
                 given(sessionService.joinSession(anyString(), any(SessionPutDTO.class))).willReturn(testSession);
+                given(sessionService.getJoinedUsernames(Mockito.any())).willReturn(List.of("HostUser", "Joiner"));
+                given(sessionService.getHostUsername(Mockito.any())).willReturn("HostUser");
 
                 SessionPutDTO sessionPutDTO = new SessionPutDTO();
                 sessionPutDTO.setToken("userToken");
@@ -150,7 +154,8 @@ class SessionControllerTest {
                                 .andExpect(status().isOk())
                                 .andExpect(jsonPath("$.sessionCode", is(testSession.getSessionCode())))
                                 .andExpect(jsonPath("$.sessionId", is(1)))
-                                .andExpect(jsonPath("$.sessionToken", is(testSession.getSessionToken())));
+                                .andExpect(jsonPath("$.sessionToken", is(testSession.getSessionToken())))
+                                .andExpect(jsonPath("$.hostUsername", is("HostUser")));
         }
 
         // Getting a session for joining not successfully
@@ -405,6 +410,7 @@ class SessionControllerTest {
                 state.setVotesReceived(2);
                 state.setTotalRounds(5);
                 state.setUsernames(List.of("Alice", "Bob", "Charlie"));
+                state.setHostUsername("Alice");
 
                 given(sessionService.getSessionState("test1234")).willReturn(state);
 
@@ -419,7 +425,8 @@ class SessionControllerTest {
                                 .andExpect(jsonPath("$.joinedUsers", is(3)))
                                 .andExpect(jsonPath("$.votesReceived", is(2)))
                                 .andExpect(jsonPath("$.totalRounds", is(5)))
-                                .andExpect(jsonPath("$.usernames", hasSize(3)));
+                                .andExpect(jsonPath("$.usernames", hasSize(3)))
+                                .andExpect(jsonPath("$.hostUsername", is("Alice")));
         }
 
         @Test
@@ -516,6 +523,7 @@ class SessionControllerTest {
                 // The second call for usernames
                 List<String> mockUsernames = List.of("Alice", "Bob", "Charlie");
                 given(sessionService.getJoinedUsernames(session)).willReturn(mockUsernames);
+                given(sessionService.getHostUsername(session)).willReturn("Alice");
 
                 MockHttpServletRequestBuilder getRequest = get("/session/test1234/users")
                                 .header("Authorization", "userToken")
@@ -526,7 +534,8 @@ class SessionControllerTest {
                                 .andExpect(jsonPath("$.maxPlayers", is(5)))
                                 .andExpect(jsonPath("$.joinedUsers", is(3)))
                                 .andExpect(jsonPath("$.usernames", hasSize(3)))
-                                .andExpect(jsonPath("$.usernames[0]", is("Alice")));
+                                .andExpect(jsonPath("$.usernames[0]", is("Alice")))
+                                .andExpect(jsonPath("$.hostUsername", is("Alice")));
         }
 
         @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
@@ -1441,4 +1441,50 @@ class SessionServiceTest {
 
             assertEquals(List.of("regularUser", "guestUser"), usernames);
         }
+
+        @Test
+        void getHostUsername_hostIsUser_returnsUsername() {
+                testSession.setHostId(1L);
+
+                testUser.setUsername("hostUser");
+                Mockito.when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+
+                String result = sessionService.getHostUsername(testSession);
+
+                assertEquals("hostUser", result);
+        }
+
+        @Test
+        void getHostUsername_hostIsGuest_returnsUsername() {
+                testSession.setHostId(1L);
+
+                testGuest.setUsername("guestHost");
+                Mockito.when(userRepository.findById(1L)).thenReturn(Optional.empty());
+                Mockito.when(guestUserRepository.findById(1L)).thenReturn(Optional.of(testGuest));
+
+                String result = sessionService.getHostUsername(testSession);
+
+                assertEquals("guestHost", result);
+        }
+
+        @Test
+        void getHostUsername_hostIdIsNull_returnsNull() {
+                testSession.setHostId(null);
+
+                String result = sessionService.getHostUsername(testSession);
+
+                assertNull(result);
+        }
+
+        @Test
+        void getHostUsername_hostNotFound_returnsNull() {
+                testSession.setHostId(99L);
+
+                Mockito.when(userRepository.findById(99L)).thenReturn(Optional.empty());
+                Mockito.when(guestUserRepository.findById(99L)).thenReturn(Optional.empty());
+
+                String result = sessionService.getHostUsername(testSession);
+
+                assertNull(result);
+        }
 }


### PR DESCRIPTION
Backend portion for user tags. 
The backend exposes the host's username in every response that the frontend uses for the lobby/session, so the client can compare it with the participant list and the current users locally stored username to display the (Host) and (You) tags.